### PR TITLE
Fix: Robust frame sampling for emotion analysis (remove FPS dependency)

### DIFF
--- a/services/emotion_analysis/emotion_analysis_imp.py
+++ b/services/emotion_analysis/emotion_analysis_imp.py
@@ -34,16 +34,8 @@ class EmotionsAnalysisImp(EmotionsAnalysisService):
             self.logger.error(f"Failed to open video file: {video_path}")
             return GetEmotionPercentagesResponse(Angry=0, Disgusted=0, Fearful=0, Happy=0, Neutral=0, Sad=0, Surprised=0)
 
-        # fps = int(video.get(cv2.CAP_PROP_FPS)) or 30
-        # frame_skip = fps  # 1 frame por segundo
-        # total frames hint
-        total_frames_hint = int(video.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
-        # number of frames to process
-        TARGET_SAMPLES = 30
-        if total_frames_hint > 0:
-            frame_step = max(1, total_frames_hint // TARGET_SAMPLES)
-        else:
-            frame_step = 30
+        last_processed_second = -1
+
     
         frame_count = 0
         processed_frames = 0
@@ -53,10 +45,15 @@ class EmotionsAnalysisImp(EmotionsAnalysisService):
             ret, im = video.read()
             if not ret:
                 break
-            frame_count += 1
-            # ensure to take at least one frame
-            if (frame_count - 1) % frame_step != 0:
+
+            timestamp_ms = video.get(cv2.CAP_PROP_POS_MSEC)
+            current_second = int(timestamp_ms / 500 ) # 2 frame per second 
+
+            if current_second == last_processed_second:
                 continue
+            last_processed_second = current_second
+            
+            frame_count += 1
 
             processed_frames += 1
             gray = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)
@@ -69,6 +66,7 @@ class EmotionsAnalysisImp(EmotionsAnalysisService):
                     img = extract_features(image)
                     pred = predict_emotion(self.model, img)
                     prediction_label = labels[pred.argmax()]
+                    self.logger.info(f"Prediction for frame {frame_count}: {prediction_label}")
                     predictions.append(prediction_label)
             except cv2.error as e:
                 self.logger.error(f"OpenCV error: {e}")

--- a/services/emotion_analysis/emotion_analysis_imp.py
+++ b/services/emotion_analysis/emotion_analysis_imp.py
@@ -34,9 +34,17 @@ class EmotionsAnalysisImp(EmotionsAnalysisService):
             self.logger.error(f"Failed to open video file: {video_path}")
             return GetEmotionPercentagesResponse(Angry=0, Disgusted=0, Fearful=0, Happy=0, Neutral=0, Sad=0, Surprised=0)
 
-        fps = int(video.get(cv2.CAP_PROP_FPS)) or 30
-        frame_skip = fps  # 1 frame por segundo
-
+        # fps = int(video.get(cv2.CAP_PROP_FPS)) or 30
+        # frame_skip = fps  # 1 frame por segundo
+        # total frames hint
+        total_frames_hint = int(video.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+        # number of frames to process
+        TARGET_SAMPLES = 30
+        if total_frames_hint > 0:
+            frame_step = max(1, total_frames_hint // TARGET_SAMPLES)
+        else:
+            frame_step = 30
+    
         frame_count = 0
         processed_frames = 0
         face_count = 0
@@ -46,9 +54,9 @@ class EmotionsAnalysisImp(EmotionsAnalysisService):
             if not ret:
                 break
             frame_count += 1
-
-            if frame_count % frame_skip != 0:
-                continue  # pula frames intermediários
+            # ensure to take at least one frame
+            if (frame_count - 1) % frame_step != 0:
+                continue
 
             processed_frames += 1
             gray = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)


### PR DESCRIPTION
###  Problem
The emotion analysis pipeline previously relied on video FPS metadata to decide which frames to process (approximately **1 frame per second**):

```python
frame_skip = fps
if frame_count % frame_skip != 0:
    continue
```
This approach is fragile and fails for many real-world videos where FPS metadata is incorrect or unreliable (e.g. variable frame rate videos, broken timestamps, or extremely short durations).

In these cases:

CAP_PROP_FPS may return extremely large values (thousands or more)

frame_skip becomes larger than the total number of frames

No frame ever satisfies the modulo condition

Result:
```
Frames actually processed: 0
Total faces detected: 0
No faces detected or no predictions made.
```
This caused valid videos containing faces to return empty emotion analysis results.
✅ Solution

This pull request introduces timestamp-based frame sampling to make frame processing deterministic and time-driven rather than metadata-driven.

The pipeline now processes frames based on video playback time, targeting a fixed temporal resolution:

Frames are sampled using cv2.CAP_PROP_POS_MSEC

A new logical “time bucket” is computed per frame

Only one frame is processed per bucket

Current configuration processes ~2 frames per second
```
timestamp_ms = video.get(cv2.CAP_PROP_POS_MSEC)
current_second = int(timestamp_ms / 500)  # 2 frames per second

if current_second == last_processed_second:
    continue
last_processed_second = current_second

```
This ensures consistent sampling across the video timeline, regardless of FPS variability.

🛡️ Benefits

Predictable and bounded frame processing

Avoids reliance on cv2.CAP_PROP_FPS

Stable behavior for:

Variable frame rate (VFR) videos

Fast-encoded or short-duration videos

Webcam and mobile recordings

Prevents unnecessary processing of near-duplicate frames

Improved performance and easier debugging

🔧 Implementation Details

Introduced timestamp-based sampling using CAP_PROP_POS_MSEC

Processes at most one frame per 500ms (≈ 2 FPS)

Preserved existing face detection and emotion prediction logic

Added per-frame logging for predicted emotions

No changes to model inference or preprocessing steps

🧪 Logging & Debugging

The following logs are now stable and meaningful:

Total frames processed

Frames actually processed

Total faces detected

Per-frame emotion predictions (for processed frames)

This makes it easier to trace model behavior over time and correlate predictions with specific frames.

⚠️ Backward Compatibility

No API changes

No schema changes

No model changes

Fully backward compatible

📌 Notes

The sampling rate can be easily tuned by adjusting the divisor used with CAP_PROP_POS_MSEC:

1000 → ~1 frame per second

500 → ~2 frames per second (current)

250 → ~4 frames per second

This allows a clear trade-off between performance and temporal resolution.