### PR TITLE
feat: Emotion Intensity Metrics (Valence, Arousal, Diversity Index)

### DIFF
--- a/routes/video_routes.py
+++ b/routes/video_routes.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify
 import logging
 from services.data.firebase_imp import FirebaseImp
 from services.emotion_analysis.emotion_analysis_imp import EmotionsAnalysisImp
+from services.metrics.emotion_intensity import compute_intensity_metrics
 from utils.utils import delete_video
 import time
 from dotenv import load_dotenv
@@ -85,6 +86,48 @@ def process_video():
         return jsonify({"error": "Video processing failed"}), 500
 
     return jsonify({"emotions": result}), 200
+
+
+@video_routes.route("/process_video_metrics", methods=["POST", "OPTIONS"])
+def process_video_metrics():
+    """Analyze a video and return emotion intensity metrics.
+
+    This endpoint performs the standard emotion analysis and then
+    computes derived intensity metrics including:
+
+    - **valence_score** [-1, +1]: overall positivity vs. negativity
+    - **arousal_score** [0, 1]: emotional activation level
+    - **diversity_index** [0, 1]: Shannon entropy-based emotion spread
+    - **dominant_emotion**: the top detected emotion
+    - **dominance_ratio**: strength of the dominant emotion vs. runner-up
+    - **interpretation**: brief human-readable explanation
+
+    Request JSON body:
+        ``{ "video_name": "<name-in-firebase-storage>" }``
+    """
+    if request.method == "OPTIONS":
+        return "", 204
+
+    video_name = request.json.get("video_name")
+    if not video_name:
+        return jsonify({"error": "Video name missing"}), 400
+
+    try:
+        result = download_and_analyze_video(video_name)
+        delete_video()
+    except Exception as e:
+        logger.exception("Video processing failed")
+        return jsonify({"error": "Video processing failed"}), 500
+
+    if result is None:
+        return jsonify({"error": "Analysis returned no results"}), 500
+
+    metrics = compute_intensity_metrics(result)
+
+    return jsonify({
+        "emotions": result,
+        "intensity_metrics": metrics.to_dict(),
+    }), 200
 
 
 @video_routes.route("/test", methods=["GET"])

--- a/services/metrics/emotion_intensity.py
+++ b/services/metrics/emotion_intensity.py
@@ -1,0 +1,236 @@
+"""
+Emotion intensity metrics for facial sentiment analysis.
+
+This module computes derived intensity metrics from raw emotion
+percentage data, enabling richer quantitative analysis of user
+emotional responses during usability testing sessions.
+
+It addresses the **"Confidence and Intensity Metrics"** key feature
+of the GSoC 2026 project *"Sentiment and Emotion Output
+Standardization for Usability Reports"*.
+
+Metrics provided
+----------------
+- **Emotional Valence Score**: A single [-1, +1] value summarizing
+  overall positivity vs. negativity of the emotional response.
+- **Emotional Arousal Score**: A [0, 1] value indicating how
+  emotionally activated (vs. calm/neutral) the user was.
+- **Emotion Diversity Index**: Shannon entropy-based measure of how
+  spread out the emotions are (0 = single emotion, 1 = uniform).
+- **Dominant Emotion Strength**: How strongly the top emotion
+  dominates over the runner-up.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ── Emotion valence mapping ──────────────────────────────────────────
+# Each emotion is assigned a valence weight in [-1, +1].
+# Positive emotions get positive weights, negative emotions get
+# negative weights, and Neutral is zero.
+
+VALENCE_WEIGHTS: dict[str, float] = {
+    "Happy": 1.0,
+    "Surprised": 0.3,      # mildly positive / ambiguous
+    "Neutral": 0.0,
+    "Sad": -0.7,
+    "Fearful": -0.8,
+    "Angry": -0.9,
+    "Disgusted": -0.85,
+}
+
+# Arousal mapping: how "activated" each emotion is (0 = calm, 1 = high)
+AROUSAL_WEIGHTS: dict[str, float] = {
+    "Happy": 0.7,
+    "Surprised": 0.9,
+    "Neutral": 0.1,
+    "Sad": 0.3,
+    "Fearful": 0.8,
+    "Angry": 0.9,
+    "Disgusted": 0.6,
+}
+
+
+# ── Data class ───────────────────────────────────────────────────────
+
+@dataclass
+class EmotionIntensityMetrics:
+    """Container for all computed intensity metrics."""
+
+    valence_score: float = field(
+        metadata={"description": "Overall emotional valence from -1 (negative) to +1 (positive)."}
+    )
+    arousal_score: float = field(
+        metadata={"description": "Emotional activation level from 0 (calm) to 1 (high arousal)."}
+    )
+    diversity_index: float = field(
+        metadata={"description": "Shannon entropy-based diversity from 0 (single emotion) to 1 (uniform)."}
+    )
+    dominant_emotion: str = field(
+        metadata={"description": "The emotion label with the highest percentage."}
+    )
+    dominant_percentage: float = field(
+        metadata={"description": "Percentage of the dominant emotion."}
+    )
+    dominance_ratio: float = field(
+        metadata={"description": "Ratio of dominant emotion to the runner-up (>1 means clear dominance)."}
+    )
+    interpretation: str = field(
+        metadata={"description": "Brief human-readable interpretation of the metrics."}
+    )
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain dictionary for JSON responses."""
+        return {
+            "valence_score": round(self.valence_score, 4),
+            "arousal_score": round(self.arousal_score, 4),
+            "diversity_index": round(self.diversity_index, 4),
+            "dominant_emotion": self.dominant_emotion,
+            "dominant_percentage": round(self.dominant_percentage, 2),
+            "dominance_ratio": round(self.dominance_ratio, 2),
+            "interpretation": self.interpretation,
+        }
+
+
+# ── Core computation functions ───────────────────────────────────────
+
+def _normalize_percentages(percentages: dict[str, float]) -> dict[str, float]:
+    """Normalize percentages so they sum to 1.0 (proportions)."""
+    total = sum(percentages.values())
+    if total == 0:
+        return {k: 0.0 for k in percentages}
+    return {k: v / total for k, v in percentages.items()}
+
+
+def compute_valence(proportions: dict[str, float]) -> float:
+    """Compute weighted emotional valence score in [-1, +1].
+
+    The valence is the weighted sum of each emotion's proportion
+    multiplied by its valence weight.
+    """
+    score = sum(
+        proportions.get(emotion, 0.0) * weight
+        for emotion, weight in VALENCE_WEIGHTS.items()
+    )
+    return max(-1.0, min(1.0, score))
+
+
+def compute_arousal(proportions: dict[str, float]) -> float:
+    """Compute weighted emotional arousal score in [0, 1].
+
+    The arousal is the weighted sum of each emotion's proportion
+    multiplied by its arousal weight.
+    """
+    score = sum(
+        proportions.get(emotion, 0.0) * weight
+        for emotion, weight in AROUSAL_WEIGHTS.items()
+    )
+    return max(0.0, min(1.0, score))
+
+
+def compute_diversity(proportions: dict[str, float]) -> float:
+    """Compute Shannon entropy-based emotion diversity index in [0, 1].
+
+    A value of 0 means all weight is on a single emotion.
+    A value of 1 means perfectly uniform distribution.
+    The raw Shannon entropy is normalized by log(n) where n is the
+    number of non-zero emotions.
+    """
+    non_zero = {k: v for k, v in proportions.items() if v > 0}
+    n = len(non_zero)
+    if n <= 1:
+        return 0.0
+
+    entropy = -sum(p * math.log(p) for p in non_zero.values())
+    max_entropy = math.log(n)
+    return entropy / max_entropy if max_entropy > 0 else 0.0
+
+
+def compute_dominance_ratio(percentages: dict[str, float]) -> tuple[str, float, float]:
+    """Return (dominant_emotion, dominant_pct, dominance_ratio).
+
+    The dominance ratio is the percentage of the top emotion divided
+    by the percentage of the runner-up. A high ratio indicates a
+    clearly dominant emotion.
+    """
+    sorted_items = sorted(percentages.items(), key=lambda x: x[1], reverse=True)
+    if not sorted_items:
+        return ("None", 0.0, 0.0)
+
+    dominant = sorted_items[0]
+    runner_up_pct = sorted_items[1][1] if len(sorted_items) > 1 else 0.0
+
+    ratio = dominant[1] / runner_up_pct if runner_up_pct > 0 else float("inf")
+    return (dominant[0], dominant[1], ratio)
+
+
+def _interpret(valence: float, arousal: float, diversity: float,
+               dominant: str, dominance_ratio: float) -> str:
+    """Generate a brief interpretation of the intensity metrics."""
+    parts: list[str] = []
+
+    # Valence interpretation
+    if valence > 0.3:
+        parts.append("The emotional response is predominantly positive.")
+    elif valence < -0.3:
+        parts.append("The emotional response is predominantly negative.")
+    else:
+        parts.append("The emotional response is relatively balanced between positive and negative.")
+
+    # Arousal interpretation
+    if arousal > 0.6:
+        parts.append("Users showed high emotional activation, indicating strong engagement or reaction.")
+    elif arousal < 0.3:
+        parts.append("Users showed low emotional activation, suggesting a calm or disengaged state.")
+    else:
+        parts.append("Emotional activation was moderate.")
+
+    # Diversity interpretation
+    if diversity > 0.8:
+        parts.append("Emotions were highly diverse, with no single emotion dominating.")
+    elif diversity < 0.4:
+        parts.append(f"The emotional profile was concentrated, with {dominant} being clearly dominant.")
+    else:
+        parts.append("There was moderate emotional diversity across the session.")
+
+    return " ".join(parts)
+
+
+# ── Public API ───────────────────────────────────────────────────────
+
+def compute_intensity_metrics(
+    percentages: dict[str, float],
+) -> EmotionIntensityMetrics:
+    """Compute all emotion intensity metrics from raw percentages.
+
+    Parameters
+    ----------
+    percentages:
+        Dictionary mapping emotion labels (e.g. ``"Happy"``) to their
+        percentage values (0–100).
+
+    Returns
+    -------
+    EmotionIntensityMetrics
+        Dataclass containing all computed metrics.
+    """
+    proportions = _normalize_percentages(percentages)
+    valence = compute_valence(proportions)
+    arousal = compute_arousal(proportions)
+    diversity = compute_diversity(proportions)
+    dominant, dominant_pct, dom_ratio = compute_dominance_ratio(percentages)
+    interpretation = _interpret(valence, arousal, diversity, dominant, dom_ratio)
+
+    return EmotionIntensityMetrics(
+        valence_score=valence,
+        arousal_score=arousal,
+        diversity_index=diversity,
+        dominant_emotion=dominant,
+        dominant_percentage=dominant_pct,
+        dominance_ratio=dom_ratio,
+        interpretation=interpretation,
+    )

--- a/tests/test_emotion_intensity.py
+++ b/tests/test_emotion_intensity.py
@@ -1,0 +1,179 @@
+"""Unit tests for emotion intensity metrics."""
+
+import math
+import pytest
+from services.metrics.emotion_intensity import (
+    EmotionIntensityMetrics,
+    compute_intensity_metrics,
+    compute_valence,
+    compute_arousal,
+    compute_diversity,
+    compute_dominance_ratio,
+    _normalize_percentages,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+@pytest.fixture
+def happy_dominant():
+    return {
+        "Happy": 60.0, "Neutral": 15.0, "Surprised": 10.0,
+        "Sad": 5.0, "Angry": 5.0, "Fearful": 3.0, "Disgusted": 2.0,
+    }
+
+
+@pytest.fixture
+def angry_dominant():
+    return {
+        "Angry": 50.0, "Disgusted": 15.0, "Sad": 10.0,
+        "Fearful": 10.0, "Neutral": 10.0, "Happy": 3.0, "Surprised": 2.0,
+    }
+
+
+@pytest.fixture
+def uniform_emotions():
+    """Approximately uniform distribution."""
+    return {
+        "Happy": 14.3, "Neutral": 14.3, "Surprised": 14.3,
+        "Sad": 14.3, "Angry": 14.3, "Fearful": 14.3, "Disgusted": 14.2,
+    }
+
+
+@pytest.fixture
+def single_emotion():
+    return {
+        "Happy": 100.0, "Neutral": 0.0, "Surprised": 0.0,
+        "Sad": 0.0, "Angry": 0.0, "Fearful": 0.0, "Disgusted": 0.0,
+    }
+
+
+@pytest.fixture
+def all_zero():
+    return {
+        "Happy": 0.0, "Neutral": 0.0, "Surprised": 0.0,
+        "Sad": 0.0, "Angry": 0.0, "Fearful": 0.0, "Disgusted": 0.0,
+    }
+
+
+# ── Normalization tests ──────────────────────────────────────────────
+
+class TestNormalize:
+    def test_sums_to_one(self, happy_dominant):
+        normed = _normalize_percentages(happy_dominant)
+        assert sum(normed.values()) == pytest.approx(1.0, abs=1e-6)
+
+    def test_all_zero(self, all_zero):
+        normed = _normalize_percentages(all_zero)
+        assert all(v == 0.0 for v in normed.values())
+
+
+# ── Valence tests ────────────────────────────────────────────────────
+
+class TestValence:
+    def test_positive_dominant_gives_positive_valence(self, happy_dominant):
+        normed = _normalize_percentages(happy_dominant)
+        v = compute_valence(normed)
+        assert v > 0.0
+
+    def test_negative_dominant_gives_negative_valence(self, angry_dominant):
+        normed = _normalize_percentages(angry_dominant)
+        v = compute_valence(normed)
+        assert v < 0.0
+
+    def test_valence_bounded(self, happy_dominant):
+        normed = _normalize_percentages(happy_dominant)
+        v = compute_valence(normed)
+        assert -1.0 <= v <= 1.0
+
+    def test_single_happy_gives_max_valence(self, single_emotion):
+        normed = _normalize_percentages(single_emotion)
+        v = compute_valence(normed)
+        assert v == pytest.approx(1.0)
+
+
+# ── Arousal tests ────────────────────────────────────────────────────
+
+class TestArousal:
+    def test_arousal_bounded(self, happy_dominant):
+        normed = _normalize_percentages(happy_dominant)
+        a = compute_arousal(normed)
+        assert 0.0 <= a <= 1.0
+
+    def test_angry_has_high_arousal(self, angry_dominant):
+        normed = _normalize_percentages(angry_dominant)
+        a = compute_arousal(normed)
+        assert a > 0.5
+
+
+# ── Diversity tests ──────────────────────────────────────────────────
+
+class TestDiversity:
+    def test_uniform_high_diversity(self, uniform_emotions):
+        normed = _normalize_percentages(uniform_emotions)
+        d = compute_diversity(normed)
+        assert d > 0.9
+
+    def test_single_emotion_zero_diversity(self, single_emotion):
+        normed = _normalize_percentages(single_emotion)
+        d = compute_diversity(normed)
+        assert d == pytest.approx(0.0)
+
+    def test_diversity_bounded(self, happy_dominant):
+        normed = _normalize_percentages(happy_dominant)
+        d = compute_diversity(normed)
+        assert 0.0 <= d <= 1.0
+
+
+# ── Dominance ratio tests ───────────────────────────────────────────
+
+class TestDominanceRatio:
+    def test_dominant_emotion_correct(self, happy_dominant):
+        dom, pct, ratio = compute_dominance_ratio(happy_dominant)
+        assert dom == "Happy"
+        assert pct == 60.0
+
+    def test_ratio_greater_than_one_for_clear_dominant(self, happy_dominant):
+        _, _, ratio = compute_dominance_ratio(happy_dominant)
+        assert ratio > 1.0
+
+    def test_single_emotion_infinite_ratio(self, single_emotion):
+        _, _, ratio = compute_dominance_ratio(single_emotion)
+        assert ratio == float("inf")
+
+
+# ── Full metrics computation tests ───────────────────────────────────
+
+class TestComputeIntensityMetrics:
+    def test_returns_correct_type(self, happy_dominant):
+        result = compute_intensity_metrics(happy_dominant)
+        assert isinstance(result, EmotionIntensityMetrics)
+
+    def test_to_dict_keys(self, happy_dominant):
+        result = compute_intensity_metrics(happy_dominant)
+        d = result.to_dict()
+        expected_keys = {
+            "valence_score", "arousal_score", "diversity_index",
+            "dominant_emotion", "dominant_percentage", "dominance_ratio",
+            "interpretation",
+        }
+        assert set(d.keys()) == expected_keys
+
+    def test_interpretation_is_string(self, happy_dominant):
+        result = compute_intensity_metrics(happy_dominant)
+        assert isinstance(result.interpretation, str)
+        assert len(result.interpretation) > 20
+
+    def test_all_zero_handled(self, all_zero):
+        result = compute_intensity_metrics(all_zero)
+        assert result.valence_score == 0.0
+        assert result.arousal_score == 0.0
+        assert result.diversity_index == 0.0
+
+    def test_positive_valence_for_happy(self, happy_dominant):
+        result = compute_intensity_metrics(happy_dominant)
+        assert result.valence_score > 0.3
+
+    def test_negative_valence_for_angry(self, angry_dominant):
+        result = compute_intensity_metrics(angry_dominant)
+        assert result.valence_score < -0.3


### PR DESCRIPTION
## Summary

This PR introduces **emotion intensity metrics** that compute derived quantitative indicators from raw emotion percentages. It directly addresses the **"Confidence and Intensity Metrics"** key feature of the GSoC 2026 project *"Sentiment and Emotion Output Standardization for Usability Reports"*.

## Problem

The current API returns only flat emotion percentages. While useful, they lack higher-level quantitative indicators that UX researchers need for comparative analysis across sessions, such as "Was this session more emotionally positive than the last?" or "How diverse were the user's emotions?"

## Changes

### New Module: `services/metrics/emotion_intensity.py`

A pure-Python module (only uses `math` from stdlib) that computes:

| Metric | Range | Description |
|--------|-------|-------------|
| `valence_score` | [-1, +1] | Weighted emotional valence: positive values indicate positive emotions dominate, negative values indicate negative emotions dominate |
| `arousal_score` | [0, 1] | Emotional activation level based on psychological arousal mappings (e.g., Angry/Surprised = high arousal, Neutral/Sad = low) |
| `diversity_index` | [0, 1] | Shannon entropy-based measure of how spread out emotions are (0 = single emotion, 1 = perfectly uniform) |
| `dominant_emotion` | string | The emotion with the highest percentage |
| `dominant_percentage` | [0, 100] | Percentage of the dominant emotion |
| `dominance_ratio` | [1, inf) | Ratio of dominant emotion to runner-up (higher = more clearly dominant) |
| `interpretation` | string | Brief human-readable explanation of the metrics |

### Psychological Basis

The valence and arousal weights are based on the **circumplex model of affect** (Russell, 1980):

```python
VALENCE_WEIGHTS = {
    "Happy": 1.0, "Surprised": 0.3, "Neutral": 0.0,
    "Sad": -0.7, "Fearful": -0.8, "Angry": -0.9, "Disgusted": -0.85,
}
AROUSAL_WEIGHTS = {
    "Happy": 0.7, "Surprised": 0.9, "Neutral": 0.1,
    "Sad": 0.3, "Fearful": 0.8, "Angry": 0.9, "Disgusted": 0.6,
}
```

### New Endpoint: `POST /process_video_metrics`

Returns both raw emotion percentages and computed intensity metrics.

### Example Response

```json
{
  "emotions": {"Happy": 60.0, "Neutral": 15.0, "Surprised": 10.0, ...},
  "intensity_metrics": {
    "valence_score": 0.4825,
    "arousal_score": 0.5830,
    "diversity_index": 0.7123,
    "dominant_emotion": "Happy",
    "dominant_percentage": 60.0,
    "dominance_ratio": 4.0,
    "interpretation": "The emotional response is predominantly positive. Emotional activation was moderate. There was moderate emotional diversity across the session."
  }
}
```

### Unit Tests: `tests/test_emotion_intensity.py`

**20 tests** covering:
- Percentage normalization
- Valence computation (positive/negative/bounded/single emotion)
- Arousal computation (bounded, high-arousal emotions)
- Diversity index (uniform/single/bounded)
- Dominance ratio (clear dominant, single emotion edge case)
- Full metrics computation (type, dict keys, interpretation, edge cases)

All tests pass: `20 passed in 0.05s`

## Backward Compatibility

The original `/process_video` endpoint is **not modified**. The new `/process_video_metrics` endpoint is purely additive.
