### PR TITLE
fix: resolve ZeroDivisionError in mvp.py and enable dynamic video loading

### DIFF
--- a/mvp.py
+++ b/mvp.py
@@ -30,6 +30,10 @@ def predict_emotion(model, img):
 
 def getPercentages(predictions):
     
+    if not predictions:
+        print("No predictions generated. Returning empty percentages.")
+        return {}
+        
     percentages = []
     emotionCountMap = {
         'Angry': 0,
@@ -75,8 +79,7 @@ def main(video_path, predictions):
     face_cascade = load_face_cascade()
 
     # pass in video_path or 0 for webcam
-    video = cv2.VideoCapture("fv.mp4")
-
+    video = cv2.VideoCapture(video_path)
     # Define emotion labels
     labels = {0: 'Angry', 1: 'Disgusted', 2: 'Fearful', 3: 'Happy', 4: 'Neutral', 5: 'Sad', 6: 'Surprised'}
     counter = 0


### PR DESCRIPTION
Resolves #13

### Objective
Resolves the `ZeroDivisionError` in `mvp.py` identified in #13 and allows for dynamic video path loading.

### Technical Changes
1. Updated `cv2.VideoCapture()` in `main()` to utilize the passed `video_path` argument instead of a hardcoded `fv.mp4` string.
2. Implemented an early-exit guard clause in `getPercentages()` to safely return an empty dictionary if the `predictions` array is empty. This prevents a fatal crash when processing edge cases (e.g., corrupted files or frames with no detectable faces).

### Validation
Verified locally by executing `mvp.py` against a nonexistent/empty video file. The application successfully logs `No predictions generated. Returning empty percentages.` and exits cleanly instead of throwing a Python traceback.

### Terminal Proof:
```bash
(venv) kunal@kunal-OMEN-by-HP-Gaming-Laptop-16-wf1xxx:~/.../facial-sentiment-analysis-api$ python3 mvp.py dummy_nonexistent_video.mp4
# ... [TensorFlow initialization logs omitted for brevity] ...
[]
No predictions generated. Returning empty percentages.
```