### PR TITLE
feat(storage): add local fallback when Firebase is not configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
+FLASK_DEBUG=1
+FIREBASE_STORAGE_BUCKET=your-bucket-name.appspot.com
 FIREBASE_STORAGE_BUCKET="" # Firebase storage bucket of your Ruxailab project

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
-FLASK_DEBUG=1
+# Storage Mode
+USE_LOCAL_STORAGE=true
+
+# Firebase (only needed if USE_LOCAL_STORAGE=false)
 FIREBASE_STORAGE_BUCKET=your-bucket-name.appspot.com
-FIREBASE_STORAGE_BUCKET="" # Firebase storage bucket of your Ruxailab project

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ node_modules/
 service-account.json
 *.mp4
 *.lock
+
+.venv/
+.vscode/

--- a/routes/video_routes.py
+++ b/routes/video_routes.py
@@ -16,10 +16,13 @@ video_routes = Blueprint("video_routes", __name__)
 
 storage_bucket = os.getenv("FIREBASE_STORAGE_BUCKET")
 
-if not storage_bucket:
-    raise RuntimeError("FIREBASE_STORAGE_BUCKET not set")
-
-firebase_service = FirebaseImp(storage_bucket=storage_bucket)
+firebase_service = None
+if storage_bucket:
+    firebase_service = FirebaseImp(storage_bucket=storage_bucket)
+else:
+    logging.getLogger(__name__).warning(
+        "FIREBASE_STORAGE_BUCKET not set; /process_video will fail until configured."
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +38,10 @@ def analyze_clip(emotion_analysis_service, video_path):
         return None
 
 def download_and_analyze_video(video_name):
+    if not firebase_service:
+        raise RuntimeError(
+            "FIREBASE_STORAGE_BUCKET not set. Set it in your environment or a .env file."
+        )
     logger.info(f"Attempting to download video: {video_name} from storage.")
     try:
         local_path = f"static/videos/{video_name}"

--- a/routes/video_routes.py
+++ b/routes/video_routes.py
@@ -6,8 +6,9 @@ from utils.utils import delete_video
 import time
 from dotenv import load_dotenv
 import os
+import requests
 from moviepy.video.io.ffmpeg_tools import ffmpeg_extract_subclip
-from moviepy.editor import VideoFileClip
+from moviepy import VideoFileClip
 
 load_dotenv()
 
@@ -49,7 +50,7 @@ def download_and_analyze_video(video_name):
         clip = VideoFileClip(video_path)
         if clip.fps > 1:
             logger.warning(f"High FPS detected ({clip.fps}). Reducing to 1fps.")
-            clip = clip.set_fps(1)
+            clip = clip.with_fps(1)
         trimmed_path = video_path.replace(".webm", "_trimmed.mp4")
         clip.write_videofile(trimmed_path, codec="libx264", audio=False, logger=None)
         video_path = trimmed_path
@@ -92,7 +93,7 @@ def call_hello_world():
     logger.info("Attempting to call test firebase function.")
     firebase_function_url = "https://europe-west1-backend-tfg-1d0d5.cloudfunctions.net/hello_world"
     try: 
-        response = request.get(firebase_function_url)
+        response = requests.get(firebase_function_url)
         if response.status_code == 200:
             return jsonify(response.json()), 200
         else:

--- a/routes/video_routes.py
+++ b/routes/video_routes.py
@@ -15,14 +15,28 @@ load_dotenv()
 video_routes = Blueprint("video_routes", __name__)
 
 storage_bucket = os.getenv("FIREBASE_STORAGE_BUCKET")
+use_local = os.getenv("USE_LOCAL_STORAGE", "false").lower() == "true"
 
 firebase_service = None
-if storage_bucket:
-    firebase_service = FirebaseImp(storage_bucket=storage_bucket)
-else:
-    logging.getLogger(__name__).warning(
-        "FIREBASE_STORAGE_BUCKET not set; /process_video will fail until configured."
-    )
+storage_service = None
+
+def get_storage_service():
+    global storage_service
+
+    if storage_service is not None:
+        return storage_service
+
+    if use_local:
+        from services.data.local_storage_imp import LocalStorageImp
+        storage_service = LocalStorageImp()
+    else:
+        if not storage_bucket:
+            raise RuntimeError(
+                "Firebase not configured. Set FIREBASE_STORAGE_BUCKET or USE_LOCAL_STORAGE=true"
+            )
+        storage_service = FirebaseImp(storage_bucket=storage_bucket)
+
+    return storage_service
 
 logger = logging.getLogger(__name__)
 
@@ -38,15 +52,17 @@ def analyze_clip(emotion_analysis_service, video_path):
         return None
 
 def download_and_analyze_video(video_name):
-    if not firebase_service:
-        raise RuntimeError(
-            "FIREBASE_STORAGE_BUCKET not set. Set it in your environment or a .env file."
-        )
+    # if not firebase_service:
+    #     raise RuntimeError(
+    #         "FIREBASE_STORAGE_BUCKET not set. Set it in your environment or a .env file."
+    #     )
+    storage_service = get_storage_service()
     logger.info(f"Attempting to download video: {video_name} from storage.")
     try:
         local_path = f"static/videos/{video_name}"
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
-        video_path = firebase_service.download_video_from_storage(video_name)
+        storage_service = get_storage_service()
+        video_path = storage_service.download_video_from_storage(video_name)
         logger.info(f"Video downloaded successfully to: {video_path}")
     except Exception as e:
         logger.error(f"Failed to download video: {e}")

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Package for service implementations."""

--- a/services/data/__init__.py
+++ b/services/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data layer services package."""

--- a/services/data/local_storage_imp.py
+++ b/services/data/local_storage_imp.py
@@ -1,0 +1,11 @@
+import os
+import shutil
+
+class LocalStorageImp:
+    def __init__(self, base_path="local_storage"):
+        self.base_path = base_path
+        os.makedirs(base_path, exist_ok=True)
+
+    def download_video_from_storage(self, video_name):
+        local_file = os.path.join(self.base_path, video_name)
+        return local_file


### PR DESCRIPTION
## Summary

This PR adds a local storage fallback to allow running the API without Firebase configuration.

## Problem

Currently, the application crashes at startup if Firebase credentials are not configured:

`google.auth.exceptions.DefaultCredentialsError`

This prevents contributors from running the project locally.

## Solution

- Added conditional Firebase initialization
- Implemented local storage fallback
- Introduced `USE_LOCAL_STORAGE` environment variable
- Prevented Firebase initialization during import

## Changes

- Updated `routes/video_routes.py`
- Added `USE_LOCAL_STORAGE` support
- Improved storage initialization logic
- Updated `.env.example`

## Testing

- Verified app runs without Firebase credentials
- Tested `/hello` endpoint locally
- Tested `/test` endpoint and confirmed external request handling

## Local Testing Output

Application started successfully without Firebase credentials:

```
Starting the application
Running on http://localhost:5000
```

Tested /hello endpoint:

```
"GET /hello HTTP/1.1" 200 -
```

Tested /test endpoint:

```
Attempting to call test firebase function.
Failed to call firebase function: 404
```

## Result

The project can now run locally without Firebase setup, improving developer onboarding.