### PR TITLE
feat(schema): add FacialEmotionOutput for multimodal engine integration

### DIFF
--- a/schemas/multimodal_output_schema.py
+++ b/schemas/multimodal_output_schema.py
@@ -1,0 +1,101 @@
+"""
+Standardized output schema for multimodal sentiment fusion.
+
+Converts the facial-sentiment-analysis-api emotion percentage output
+into the dict format expected by MultimodalSentimentEngine.analyze()
+in the sentiment-analysis-api repo.
+
+Usage:
+    from schemas.multimodal_output_schema import FacialEmotionOutput
+
+    result = GetEmotionPercentagesResponse(...)
+    payload = FacialEmotionOutput.from_response(result)
+    # payload.to_multimodal_dict() → ready for /multimodal/analyze
+"""
+
+from pydantic import BaseModel, Field
+from schemas.emotion_schema import GetEmotionPercentagesResponse
+
+
+class FacialEmotionOutput(BaseModel):
+    """
+    Wraps GetEmotionPercentagesResponse and exposes a conversion method
+    that produces the facial_emotions dict expected by the
+    MultimodalSentimentEngine.
+
+    The MultimodalSentimentEngine expects:
+        {emotion_label: percentage_float, ...}
+    where percentage values are in the range 0.0 to 100.0 and labels
+    match the 7-class taxonomy used by the facial CNN model.
+    """
+
+    Angry:     float = Field(ge=0.0, le=100.0)
+    Disgusted: float = Field(ge=0.0, le=100.0)
+    Fearful:   float = Field(ge=0.0, le=100.0)
+    Happy:     float = Field(ge=0.0, le=100.0)
+    Neutral:   float = Field(ge=0.0, le=100.0)
+    Sad:       float = Field(ge=0.0, le=100.0)
+    Surprised: float = Field(ge=0.0, le=100.0)
+
+    @classmethod
+    def from_response(
+        cls, response: GetEmotionPercentagesResponse
+    ) -> "FacialEmotionOutput":
+        """
+        Build a FacialEmotionOutput from a GetEmotionPercentagesResponse.
+
+        Args:
+            response: the Pydantic model returned by EmotionsAnalysisImp
+
+        Returns:
+            FacialEmotionOutput instance ready for to_multimodal_dict()
+        """
+        return cls(
+            Angry=response.Angry,
+            Disgusted=response.Disgusted,
+            Fearful=response.Fearful,
+            Happy=response.Happy,
+            Neutral=response.Neutral,
+            Sad=response.Sad,
+            Surprised=response.Surprised,
+        )
+
+    def to_multimodal_dict(self) -> dict:
+        """
+        Convert to the facial_emotions dict format expected by
+        MultimodalSentimentEngine.analyze().
+
+        Returns:
+            dict of {emotion_label: percentage_float}
+            Example:
+                {
+                    'Angry': 2.5,
+                    'Disgusted': 0.0,
+                    'Fearful': 1.2,
+                    'Happy': 61.3,
+                    'Neutral': 28.0,
+                    'Sad': 5.0,
+                    'Surprised': 2.0
+                }
+        """
+        return {
+            'Angry':     self.Angry,
+            'Disgusted': self.Disgusted,
+            'Fearful':   self.Fearful,
+            'Happy':     self.Happy,
+            'Neutral':   self.Neutral,
+            'Sad':       self.Sad,
+            'Surprised': self.Surprised,
+        }
+
+    def dominant_emotion(self) -> tuple:
+        """
+        Return the emotion with the highest percentage and its value.
+
+        Returns:
+            (label: str, percentage: float)
+            Example: ('Happy', 61.3)
+        """
+        emotions = self.to_multimodal_dict()
+        label = max(emotions, key=emotions.get)
+        return label, emotions[label]


### PR DESCRIPTION
## Summary

The facial-sentiment-analysis-api and sentiment-analysis-api currently have no shared contract — the facial API returns a
GetEmotionPercentagesResponse Pydantic model but there is no standardized way to convert that into the format the MultimodalSentimentEngine expects.

This PR adds that conversion layer.

## New File — `schemas/multimodal_output_schema.py`

`FacialEmotionOutput` is a Pydantic wrapper around
`GetEmotionPercentagesResponse` that exposes two conversion methods:

**`from_response(response)`**
Converts a `GetEmotionPercentagesResponse` into a validated `FacialEmotionOutput` with field-level range constraints (0.0–100.0 per emotion). Fails fast on out-of-range values rather than silently passing bad data downstream.

**`to_multimodal_dict()`**
Produces the `{emotion_label: percentage}` dict format expected by `MultimodalSentimentEngine.analyze(facial_emotions=...)` in the sentiment-analysis-api repo (PR #39).

**`dominant_emotion()`**
Returns `(label, percentage)` for the highest-scoring emotion — useful for logging and single-label summaries without reimplementing `max()` at every call site.

## Integration Boundary

```
facial-sentiment-analysis-api
        |
        | GetEmotionPercentagesResponse
        v
FacialEmotionOutput.from_response()
        |
        | .to_multimodal_dict()
        v
MultimodalSentimentEngine.analyze(facial_emotions={...})
        |
        | fused prediction
        v
sentiment-analysis-api /multimodal/analyze (PR #39)
```

## Example
```python
from schemas.multimodal_output_schema import FacialEmotionOutput

response = emotion_analysis_service.get_emotion_percentages(video_path)
output = FacialEmotionOutput.from_response(response)

# Ready for MultimodalSentimentEngine 
facial_dict = output.to_multimodal_dict()
# {'Angry': 2.5, 'Happy': 61.3, 'Neutral': 28.0, ...}

label, pct = output.dominant_emotion()
# ('Happy', 61.3)
```

## Relation to GSoC 2026

This is the integration boundary between both RUXAILAB sentiment repos for the Multimodal Sentiment Analysis Engine project. PR #21 and #22 established consistent logging across both repos. This PR establishes the data contract between them.